### PR TITLE
Fix PHP warnings

### DIFF
--- a/src/Elements/ElementBase.php
+++ b/src/Elements/ElementBase.php
@@ -175,7 +175,7 @@ underscore (_)');
    */
   public function checkValidUrl($url) {
     // Use php filter_var with validate url flag, and must be absolute.
-    if (is_string($url) && filter_var($url, FILTER_VALIDATE_URL, FILTER_FLAG_HOST_REQUIRED)) {
+    if (is_string($url) && filter_var($url, FILTER_VALIDATE_URL)) {
       return TRUE;
     }
     // Invalid url so throw an exception.

--- a/src/Elements/FeedElement.php
+++ b/src/Elements/FeedElement.php
@@ -16,17 +16,17 @@ class FeedElement extends ElementBase implements FeedElementInterface {
   /**
    * @var array
    */
-  protected $products;
+  protected $products = [];
 
   /**
    * @var array
    */
-  protected $brands;
+  protected $brands = [];
 
   /**
    * @var array
    */
-  protected $categories;
+  protected $categories = [];
 
   /**
    * @var bool

--- a/src/ProductFeed.php
+++ b/src/ProductFeed.php
@@ -170,7 +170,7 @@ class ProductFeed implements ProductFeedInterface {
       // Element have a #name?
       if (isset($element['#name']) && !empty($element['#name'])) {
         // Create new child on parent and change element_xml to child.
-        $element_xml = $element_xml->addChild($element['#name'], ($element['#value'] ?: null));
+        $element_xml = $element_xml->addChild($element['#name'], ($element['#value'] ?? null));
       }
 
       // Have attributes to add?


### PR DESCRIPTION
1. Removed deprecated filter_var flag `FILTER_FLAG_HOST_REQUIRED`
2. Initialized protected variables as empty arrays to prevent warnings on `count()` calls
3. Replaced `$element['#value'] ?:` by `$element['#value'] ??` to prevent warnings when `#value` key is missing in array.